### PR TITLE
Implement JWT verify endpoint

### DIFF
--- a/tpms-api/src/main/java/com/tpms/controller/AuthController.java
+++ b/tpms-api/src/main/java/com/tpms/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.tpms.dto.JwtResponse;
 import com.tpms.dto.LoginRequest;
 import com.tpms.dto.SignupRequest;
 import com.tpms.service.AuthService;
+import com.tpms.security.JwtTokenProvider;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -19,9 +21,11 @@ import jakarta.validation.Valid;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, JwtTokenProvider jwtTokenProvider) {
         this.authService = authService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     /**
@@ -40,5 +44,19 @@ public class AuthController {
     public ResponseEntity<JwtResponse> login(@Valid @RequestBody LoginRequest request) {
         String token = authService.login(request);
         return ResponseEntity.ok(new JwtResponse(token));
+    }
+
+    /**
+     * Verify the provided JWT.
+     */
+    @GetMapping("/verify")
+    public ResponseEntity<Void> verify(@RequestHeader(value = "Authorization", required = false) String header) {
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (jwtTokenProvider.validateToken(token)) {
+                return ResponseEntity.ok().build();
+            }
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 }

--- a/tpms-api/src/test/java/com/tpms/controller/AuthControllerTest.java
+++ b/tpms-api/src/test/java/com/tpms/controller/AuthControllerTest.java
@@ -1,0 +1,46 @@
+package com.tpms.controller;
+
+import com.tpms.security.JwtTokenProvider;
+import com.tpms.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    void verifyValidTokenReturnsOk() throws Exception {
+        Mockito.when(jwtTokenProvider.validateToken("valid"))
+                .thenReturn(true);
+
+        mockMvc.perform(get("/api/auth/verify")
+                .header("Authorization", "Bearer valid"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void verifyInvalidTokenReturnsUnauthorized() throws Exception {
+        Mockito.when(jwtTokenProvider.validateToken("bad"))
+                .thenReturn(false);
+
+        mockMvc.perform(get("/api/auth/verify")
+                .header("Authorization", "Bearer bad"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- add `/api/auth/verify` handler
- check token using `JwtTokenProvider`
- return 200 OK if valid otherwise 401
- cover new endpoint with unit tests

## Testing
- `mvn -Djava.net.preferIPv4Stack=true -pl tpms-api test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684466e89780832090ed939bc8a81283