### PR TITLE
Use /profile/{id} for student API

### DIFF
--- a/tpms-api/src/main/resources/static/js/admin.js
+++ b/tpms-api/src/main/resources/static/js/admin.js
@@ -102,12 +102,12 @@ class APIService {
   }
 
   // Student endpoints
-  async getStudentProfile() {
-    return this.request("/students/profile")
+  async getStudentProfile(studentId) {
+    return this.request(`/profile/${encodeURIComponent(studentId)}`)
   }
 
-  async updateStudentProfile(profileData) {
-    return this.request("/students/profile", {
+  async updateStudentProfile(studentId, profileData) {
+    return this.request(`/profile/${encodeURIComponent(studentId)}`, {
       method: "PUT",
       body: JSON.stringify(profileData),
     })

--- a/tpms-api/src/main/resources/static/js/api.js
+++ b/tpms-api/src/main/resources/static/js/api.js
@@ -100,12 +100,12 @@ class APIService {
   }
 
   // Student endpoints
-  async getStudentProfile() {
-    return this.request("/students/profile")
+  async getStudentProfile(studentId) {
+    return this.request(`/profile/${encodeURIComponent(studentId)}`)
   }
 
-  async updateStudentProfile(profileData) {
-    return this.request("/students/profile", {
+  async updateStudentProfile(studentId, profileData) {
+    return this.request(`/profile/${encodeURIComponent(studentId)}`, {
       method: "PUT",
       body: JSON.stringify(profileData),
     })


### PR DESCRIPTION
## Summary
- switch student profile endpoints in api.js and admin.js to `/api/profile/{id}`

## Testing
- `mvn -q -f tpms-api/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_684467fed1e883209371c09277378221