### PR TITLE
Fix profile access check and add controller tests

### DIFF
--- a/tpms-api/src/main/java/com/tpms/controller/ProfileController.java
+++ b/tpms-api/src/main/java/com/tpms/controller/ProfileController.java
@@ -16,14 +16,14 @@ public class ProfileController {
     private final StudentService studentService;
     public ProfileController(StudentService ss) { this.studentService = ss; }
 
-    @PreAuthorize("hasRole('ADMIN') or #studentId == authentication.name")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or (hasRole('ROLE_STUDENT') and #studentId == authentication.name)")
     @GetMapping("/{studentId}")
     public ResponseEntity<StudentDto> getProfile(@PathVariable String studentId) {
         Optional<Student> opt = studentService.getStudentById(studentId);
         return opt.map(StudentMapper::toDto).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
     }
 
-    @PreAuthorize("hasRole('ADMIN') or #studentId == authentication.name")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or (hasRole('ROLE_STUDENT') and #studentId == authentication.name)")
     @PutMapping("/{studentId}")
     public ResponseEntity<StudentDto> updateProfile(@PathVariable String studentId,
                                                     @RequestBody StudentDto dto) {

--- a/tpms-api/src/test/java/com/tpms/controller/ProfileControllerTest.java
+++ b/tpms-api/src/test/java/com/tpms/controller/ProfileControllerTest.java
@@ -1,0 +1,49 @@
+package com.tpms.controller;
+
+import com.tpms.model.Student;
+import com.tpms.service.StudentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.Import;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WebMvcTest(ProfileController.class)
+@Import(ProfileControllerTest.TestConfig.class)
+class ProfileControllerTest {
+
+    @Configuration
+    @EnableMethodSecurity
+    static class TestConfig {}
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StudentService studentService;
+
+    @Test
+    @WithMockUser(username="S001", roles="STUDENT")
+    void studentCanAccessOwnProfile() throws Exception {
+        when(studentService.getStudentById("S001"))
+                .thenReturn(java.util.Optional.of(new Student("S001","John","CS","j@e.com",3.0)));
+        mockMvc.perform(get("/api/profile/S001"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username="admin", roles="ADMIN")
+    void adminCanAccessAnyProfile() throws Exception {
+        when(studentService.getStudentById("S001"))
+                .thenReturn(java.util.Optional.of(new Student("S001","John","CS","j@e.com",3.0)));
+        mockMvc.perform(get("/api/profile/S001"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- update `@PreAuthorize` conditions in `ProfileController`
- add `ProfileControllerTest` verifying student and admin access

## Testing
- `mvn -q -pl tpms-api test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844686f75488320b4f0197795d7d808