### PR TITLE
Add default admin account seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# TPMS
+
+This repository contains the source code for the Training and Placement Management System (TPMS).
+
+## Development Login
+
+When running the API locally, the `DataInitializer` ensures a default administrator account exists. The credentials are for **development use only**:
+
+- **Username:** `admin`
+- **Password:** `Admin123!`
+
+Use these to access admin functionality during testing. Remember to change or disable this account in production environments.

--- a/tpms-api/src/main/java/com/tpms/config/DataInitializer.java
+++ b/tpms-api/src/main/java/com/tpms/config/DataInitializer.java
@@ -1,12 +1,16 @@
 package com.tpms.config;
 
 import com.tpms.model.Role;
+import com.tpms.model.Account;
+import com.tpms.repository.AccountRepository;
 import com.tpms.repository.RoleRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Seeds the roles table at application startup if empty.
@@ -14,12 +18,25 @@ import java.util.List;
 @Configuration
 public class DataInitializer {
     @Bean
-    public ApplicationRunner initializer(RoleRepository roleRepository) {
+    public ApplicationRunner initializer(RoleRepository roleRepository,
+                                         AccountRepository accountRepository,
+                                         PasswordEncoder passwordEncoder) {
         return args -> {
             List<String> roles = List.of("ROLE_ADMIN", "ROLE_RECRUITER", "ROLE_TRAINER", "ROLE_STUDENT");
             for (String roleName : roles) {
                 roleRepository.findByName(roleName)
                               .orElseGet(() -> roleRepository.save(new Role(roleName)));
+            }
+
+            if (accountRepository.findByUsername("admin").isEmpty()) {
+                Role adminRole = roleRepository.findByName("ROLE_ADMIN")
+                        .orElseThrow();
+                Account admin = new Account();
+                admin.setUsername("admin");
+                admin.setEmail("admin@example.com");
+                admin.setPassword(passwordEncoder.encode("Admin123!"));
+                admin.setRoles(Set.of(adminRole));
+                accountRepository.save(admin);
             }
         };
     }


### PR DESCRIPTION
## Summary
- seed an admin account on startup if it doesn't exist
- document development credentials

## Testing
- `mvn -q -pl tpms-api test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68446876ae188320ad4f3195f33bd9c7